### PR TITLE
使用 GitHub Actions 进行自动构建

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,76 @@
+on:
+  push:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+    
+jobs:
+  build:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      # Pre build
+      - name: Get 7-digit commit SHA
+        run: echo "SHORT_SHA=$("${{ github.sha }}" | cut -c1-7)" >> $env:GITHUB_ENV
+
+      - name: Insert SHA to version string
+        run: |
+          $json = Get-Content package.json -Raw | ConvertFrom-Json
+          $json.version += "+$env:SHORT_SHA"
+          $json | ConvertTo-Json | Set-Content package.json         
+
+      - name: Modify electron-builder.yml
+        shell: pwsh
+        run: |
+          $yamlContent = Get-Content -Path electron-builder.yml -Raw
+          $yamlContent = $yamlContent -replace "target: 7z", "target: dir"
+          Set-Content -Path electron-builder.yml -Value $yamlContent  
+
+      - name: Get final akari version
+        run: |
+          $AKARI_VERSION = (Get-Content package.json | ConvertFrom-Json).version
+          echo "akari_version=$AKARI_VERSION" >> $env:GITHUB_ENV
+          
+      # Build               
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+
+      - name: Run yarn install
+        uses: borales/actions-yarn@v5.0.0
+        with:
+          cmd: install
+
+      - name: Install node-gyp
+        run: npm i node-gyp -g
+
+      - name: Build C++ addons
+        run: |          
+          $addons = Get-ChildItem -Directory .\addons
+          Write-Host "Found addons: $($addons.Count)"
+          $addons | ForEach-Object -Process {
+            Write-Host "Processing addon: $($_.FullName)"
+            Set-Location $_.FullName
+            node-gyp configure
+            node-gyp build        
+            Set-Location -Path ..\..          
+            Copy-Item -Path "$($_.FullName)\build\Release\*.node" -Destination .\src\main\native -Force
+          }        
+
+      - name: Run yarn build:win
+        uses: borales/actions-yarn@v5.0.0
+        with:
+          cmd: build:win
+
+      # Post build
+      - name: Upload build outputs
+        uses: actions/upload-artifact@v3
+        with:
+          name: League Akari-${{ env.akari_version }}
+          path: dist/win-unpacked


### PR DESCRIPTION
现在提交新的 commit 时，会进行自动构建，并上传构建产物。

由于 Actions 本身的设计限制，构建产物永远会使用 `zip` 压缩包裹一层，所以构建时选择了不打包，避免 Zip 套 7z 的情况。代价是产物体积较大，相比 7z 压缩包(~80MB)，Zip 压缩包的大小(~120MB)会增重50%。

另外，Actions 的产物大小显示的是 `所有文件原大小之和`，故体积会在 310MB 左右，这也符合解压之后的大小。

