### PR TITLE
feat: ongoing-game-panel allows you to view players' info during the lobby phase.

### DIFF
--- a/src/main/shards/ongoing-game/index.ts
+++ b/src/main/shards/ongoing-game/index.ts
@@ -217,7 +217,8 @@ export class OngoingGameMain implements IAkariShardInitDispose {
           this.state.queryStage,
           this.settings.enabled,
           this._sgp.state.isTokenReady,
-          this.settings.matchHistoryUseSgpApi
+          this.settings.matchHistoryUseSgpApi,
+          this._lc.data.lobby.lobby?.members
         ] as const,
       ([stage, enabled, tokenReady, useSgpApi]) => {
         this._log.info(
@@ -257,6 +258,12 @@ export class OngoingGameMain implements IAkariShardInitDispose {
           })
         } else if (this.state.queryStage.phase === 'in-game') {
           this._inGame({
+            mhSignal: this._mhController.signal,
+            signal: this._controller.signal,
+            force: false
+          })
+        } else if (this.state.queryStage.phase === 'lobby') {
+          this._champSelect({
             mhSignal: this._mhController.signal,
             signal: this._controller.signal,
             force: false
@@ -397,6 +404,12 @@ export class OngoingGameMain implements IAkariShardInitDispose {
         signal: this._controller.signal,
         force: true
       })
+    } else if (this.state.queryStage.phase === 'lobby') {
+      this._champSelect({
+        mhSignal: this._mhController.signal,
+        signal: this._controller.signal,
+        force: true
+      })
     }
   }
 
@@ -434,6 +447,18 @@ export class OngoingGameMain implements IAkariShardInitDispose {
         .map((t) => t.puuid)
 
       return [...m, ...t]
+    } else if (this.state.queryStage.phase === 'lobby') {
+      const lobbyState = this._lc.data.lobby
+
+      if(!lobbyState.lobby?.members) {
+        return []
+      }
+
+      const m = lobbyState.lobby.members
+        .filter((p) => p.puuid && p.puuid !== EMPTY_PUUID)
+        .map((t) => t.puuid)
+
+      return [...m]
     }
 
     return []

--- a/src/main/shards/ongoing-game/state.ts
+++ b/src/main/shards/ongoing-game/state.ts
@@ -282,6 +282,26 @@ export class OngoingGameState {
         })
 
       return teams
+    } else if (this.queryStage.phase === 'lobby') {
+
+      const lobbyState = this._lcData.lobby
+
+      if (!lobbyState.lobby?.members) {
+        return {}
+      }
+
+      const teams: Record<string, string[]> = {
+        'all': []
+      }
+
+      lobbyState.lobby.members
+        .filter((p) => p.puuid && p.puuid !== EMPTY_PUUID)
+        .map((t) => t.puuid)
+        .forEach(p => {
+          teams['all'].push(p)
+        })
+
+      return teams
     }
 
     return {}
@@ -295,6 +315,8 @@ export class OngoingGameState {
    * champ-select - 正在英雄选择阶段
    *
    * in-game - 在游戏中或游戏结算中
+   *
+   * lobby - 大厅中、匹配中、等待接受准备阶段
    */
   get queryStage() {
     if (
@@ -324,6 +346,22 @@ export class OngoingGameState {
     ) {
       return {
         phase: 'in-game' as 'champ-select' | 'in-game',
+        gameInfo: {
+          queueId: this._lcData.gameflow.session.gameData.queue.id,
+          queueType: this._lcData.gameflow.session.gameData.queue.type,
+          gameId: this._lcData.gameflow.session.gameData.gameId,
+          gameMode: this._lcData.gameflow.session.gameData.queue.gameMode
+        }
+      }
+    }
+
+    if (this._lcData.gameflow.session &&
+      (this._lcData.gameflow.session.phase === 'Lobby' ||
+      this._lcData.gameflow.session.phase === 'Matchmaking' ||
+      this._lcData.gameflow.session.phase === 'ReadyCheck')
+    ) {
+      return {
+        phase: 'lobby' as 'lobby' | 'matchmaking' | 'readyCheck',
         gameInfo: {
           queueId: this._lcData.gameflow.session.gameData.queue.id,
           queueType: this._lcData.gameflow.session.gameData.queue.type,

--- a/src/renderer-shared/components/ongoing-game-panel/PlayerInfoCard.vue
+++ b/src/renderer-shared/components/ongoing-game-panel/PlayerInfoCard.vue
@@ -21,12 +21,16 @@
     ></div>
     <div class="player-info">
       <div class="profile-icon">
-        <ChampionIcon
+        <ChampionIcon v-if="queryStage.phase!=='lobby'"
           :champion-id="championId || -1"
           round
           ring
           ring-color="#ffffff50"
           class="champion"
+        />
+        <LcuImage v-else
+          class="champion"
+          :src="summoner ? profileIconUri(summoner.profileIconId) : undefined"
         />
         <div class="level" v-if="summoner">{{ summoner.summonerLevel }}</div>
       </div>
@@ -468,6 +472,8 @@ import {
   RANKED_MEDAL_MAP
 } from './ongoing-game-utils'
 import PlayerCardTagsArea from './widgets/PlayerCardTagsArea.vue'
+import { profileIconUri } from '@renderer-shared/shards/league-client/utils'
+import LcuImage from '@renderer-shared/components/LcuImage.vue'
 
 const {
   puuid,

--- a/src/renderer-shared/components/ongoing-game-panel/ongoing-game-utils.ts
+++ b/src/renderer-shared/components/ongoing-game-panel/ongoing-game-utils.ts
@@ -29,10 +29,10 @@ export function useIdleState() {
 
   return computed(() => {
     return (
-      lc.gameflow.phase === 'Lobby' ||
+      //lc.gameflow.phase === 'Lobby' ||
       lc.gameflow.phase === 'None' ||
-      lc.gameflow.phase === 'Matchmaking' ||
-      lc.gameflow.phase === 'ReadyCheck' ||
+      //lc.gameflow.phase === 'Matchmaking' ||
+      //lc.gameflow.phase === 'ReadyCheck' ||
       lc.gameflow.phase === 'WatchInProgress' ||
       (lc.gameflow.phase !== 'InProgress' &&
         lc.champSelect.session &&

--- a/src/renderer-shared/shards/ongoing-game/store.ts
+++ b/src/renderer-shared/shards/ongoing-game/store.ts
@@ -102,7 +102,7 @@ export interface SavedInfo {
 // copied from main shard
 export type QueryStage =
   | {
-      phase: 'champ-select' | 'in-game'
+      phase: 'champ-select' | 'in-game' | 'lobby'
       gameInfo: {
         queueId: number
         queueType: string


### PR DESCRIPTION
View player statistics directly on `ongoing-game` page, saving you the trouble of searching manually.